### PR TITLE
fix: 글 작성 페이지 마커 이동 시 지도  중심으로 이동

### DIFF
--- a/src/components/common/KakaoMap/KakaoMap.tsx
+++ b/src/components/common/KakaoMap/KakaoMap.tsx
@@ -41,6 +41,7 @@ const KakaoMap: React.FC<KakaoMapProps> = ({ onMarkerAddressChange, initialPosit
 
           const sw = bounds.getSouthWest();
           const ne = bounds.getNorthEast();
+
           const newCenter = {
             lat: (sw.getLat() + ne.getLat()) / 2,
             lng: (sw.getLng() + ne.getLng()) / 2
@@ -112,6 +113,11 @@ const KakaoMap: React.FC<KakaoMapProps> = ({ onMarkerAddressChange, initialPosit
     const position = target.getPosition();
 
     setMarkerPosition({
+      lat: position.getLat(),
+      lng: position.getLng()
+    });
+
+    setCenter({
       lat: position.getLat(),
       lng: position.getLng()
     });


### PR DESCRIPTION
1. 글 작성 페이지 마커를 움직이면 지도 중심에 위치 하게 수정 
2. 최신 pull dev