### PR TITLE
fix: 무한 스크롤시 로딩 화면 제거 및  언더렌더링시 필터링전부 초기화로 변경

### DIFF
--- a/src/app/(provider)/(root)/(product)/list/all/page.tsx
+++ b/src/app/(provider)/(root)/(product)/list/all/page.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import CategoryFilter from '@/components/list/CategoryFilter';
 import { InfiniteData, useInfiniteQuery } from '@tanstack/react-query';
 import ProductList from '@/components/list/ProductList';
-import useSearchStore, { SearchStoreType } from '@/zustand/searchStore';
+import useSearchStore, { defaultCategoryList, SearchStoreType } from '@/zustand/searchStore';
 import { getAllProductList } from '@/api/listApi';
 import ProductListHeader from '@/components/list/ProductListHeader';
 import ProductListEmpty from '@/components/list/ProductListEmpty';
@@ -20,7 +20,7 @@ function ListOfAllPage() {
   } = useSearchStore<SearchStoreType>((state) => state);
 
   const defaultOptions = useMemo(() => {
-    return ['경제경영', '만화', '사회과학', '소설/시/희곡', '어린이', '에세이', '유아', '인문학', '기타'];
+    return defaultCategoryList;
   }, []);
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending } = useInfiniteQuery<
@@ -86,8 +86,6 @@ function ListOfAllPage() {
                 <ProductListEmpty />
               </div>
             )}
-
-            {isFetchingNextPage && <LoadingCenter />}
           </ProductListHeader>
         </div>
       </div>

--- a/src/app/(provider)/(root)/(product)/list/around/page.tsx
+++ b/src/app/(provider)/(root)/(product)/list/around/page.tsx
@@ -8,7 +8,7 @@ import useSearchStore, { SearchStoreType } from '@/zustand/searchStore';
 import { useUserStore } from '@/zustand/userStore';
 import ProductListHeader from '@/components/list/ProductListHeader';
 import ProductListEmpty from '@/components/list/ProductListEmpty';
-import { LoadingTop } from '@/components/common/Loading';
+import { LoadingCenter, LoadingTop } from '@/components/common/Loading';
 import { useRouter } from 'next/navigation';
 import { pageProductListType } from '@/types/list/productList.type';
 
@@ -72,11 +72,12 @@ function ListOfAroundPage() {
     <div className={'px-10 max-w-[1024px] mx-auto sm:mx-0 md:w-[550px] lg:w-[1024px]'}>
       <div className={'flex flex-col'}>
         <ProductListHeader title={'내 근처 도서목록'} keyword={keyword} address={address}>
-          {data?.pages[0].productList?.length !== 0 ? <ProductList pageList={data?.pages} /> : <ProductListEmpty />}
-          {isFetchingNextPage && (
-            <div className={'flex justify-start w-full mt-[100px]'}>
-              <LoadingTop></LoadingTop>
-            </div>
+          {isPending ? (
+            <LoadingCenter />
+          ) : data?.pages[0].productList?.length !== 0 ? (
+            <ProductList pageList={data?.pages} />
+          ) : (
+            <ProductListEmpty />
           )}
         </ProductListHeader>
       </div>

--- a/src/components/list/CategoryFilter.tsx
+++ b/src/components/list/CategoryFilter.tsx
@@ -1,6 +1,8 @@
+'use client';
+
 import { Checkbox, CheckboxProps } from 'antd';
-import React from 'react';
-import useSearchStore, { SearchStoreType } from '@/zustand/searchStore';
+import React, { useEffect } from 'react';
+import useSearchStore, { defaultCategoryList, SearchStoreType } from '@/zustand/searchStore';
 
 type CategoryFilterType = {
   checkBoxOptions: string[];
@@ -24,6 +26,10 @@ function CategoryFilter({ checkBoxOptions, showFilter, setShowFilter }: Category
   const onCheckAllChange: CheckboxProps['onChange'] = (e) => {
     setCategoryList(e.target.checked ? checkBoxOptions : []);
   };
+
+  useEffect(() => {
+    return setCategoryList(defaultCategoryList);
+  }, []);
 
   return (
     <div className="relative w-[430px] sm:w-[200px] px-[24px] py-[24px] border border-gray-300 rounded-lg">

--- a/src/zustand/searchStore.ts
+++ b/src/zustand/searchStore.ts
@@ -12,10 +12,22 @@ export type SearchStoreType = {
   setKeyword: (keyword: string) => void;
 };
 
+export const defaultCategoryList = [
+  '경제경영',
+  '만화',
+  '사회과학',
+  '소설/시/희곡',
+  '어린이',
+  '에세이',
+  '유아',
+  '인문학',
+  '기타'
+];
+
 const useSearchStore = create<SearchStoreType>()(
   immer((set) => ({
     search: {
-      categoryList: [],
+      categoryList: defaultCategoryList,
       keyword: ''
     },
     setCategoryList: (categoryList: string[]) =>


### PR DESCRIPTION
1. 무한 스크롤시 로딩 화면 제거 (예은님이 올려주신 부분)
2. 렌더링시 카테고리에 모두 체크될 수 있도록 수정
3.  언더렌더링시 필터링전부 초기화할 수 있도록 수정

